### PR TITLE
Remove obsolete version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   glouton:
     image: bleemeo/bleemeo-agent


### PR DESCRIPTION
Version top-level element is obsolete and trigger a warning.
Cf. [docker documentation](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete)